### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/yolo/brambox/boxes/util/convert.py
+++ b/yolo/brambox/boxes/util/convert.py
@@ -46,7 +46,7 @@ def parse(fmt, box_file, identify=None, offset=0, stride=1, **kwargs):
     """
 
     # Create parser
-    if type(fmt) is str:
+    if isinstance(fmt, str):
         try:
             parser = formats[fmt](**kwargs)
         except KeyError:
@@ -58,7 +58,7 @@ def parse(fmt, box_file, identify=None, offset=0, stride=1, **kwargs):
 
     # Parse bounding boxes
     if parser.parser_type == ParserType.SINGLE_FILE:
-        if type(box_file) is not str:
+        if not isinstance(box_file, str):
             raise TypeError(f'Parser <{parser.__class__.__name__}> requires a single annotation file')
         with open(box_file, parser.read_mode) as f:
             data = parser.deserialize(f.read())
@@ -90,9 +90,9 @@ def parse(fmt, box_file, identify=None, offset=0, stride=1, **kwargs):
         if identify is not None:
             data = {identify(key): value for key, value in data.items()}
     elif parser.parser_type == ParserType.MULTI_FILE:
-        if type(box_file) is str:
+        if isinstance(box_file, str):
             box_files = expand(box_file, stride, offset)
-        elif type(box_file) is list:
+        elif isinstance(box_file, list):
             box_files = box_file
         else:
             raise TypeError(f'Parser <{parser.__class__.__name__}> requires a list of annotation files or an expandable file expression')
@@ -132,7 +132,7 @@ def generate(fmt, box, path, **kwargs):
     """
 
     # Create parser
-    if type(fmt) is str:
+    if isinstance(fmt, str):
         try:
             parser = formats[fmt](**kwargs)
         except KeyError:

--- a/yolo/utils/test/datasets/coco.py
+++ b/yolo/utils/test/datasets/coco.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast/er R-CNN
 # Licensed under The MIT License [see LICENSE for details]
@@ -20,6 +21,11 @@ import uuid
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
 from pycocotools import mask as COCOmask
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 def _filter_crowd_proposals(roidb, crowd_thresh):
     """
@@ -78,7 +84,7 @@ class coco(imdb):
         }
         coco_name = image_set + year  # e.g., "val2014"
         self._data_name = (self._view_map[coco_name]
-                           if self._view_map.has_key(coco_name)
+                           if coco_name in self._view_map
                            else coco_name)
         # Dataset splits that have ground-truth annotations (test splits
         # do not have gt annotations)
@@ -143,7 +149,7 @@ class coco(imdb):
 
     def _load_rpn_roidb(self, gt_roidb):
         filename = self.config['rpn_file']
-        print 'loading {}'.format(filename)
+        print('loading {}'.format(filename))
         assert os.path.exists(filename), \
                'rpn data not found at: {}'.format(filename)
         with open(filename, 'rb') as f:
@@ -162,8 +168,8 @@ class coco(imdb):
         if osp.exists(cache_file):
             with open(cache_file, 'rb') as fid:
                 roidb = cPickle.load(fid)
-            print '{:s} {:s} roidb loaded from {:s}'.format(self.name, method,
-                                                            cache_file)
+            print('{:s} {:s} roidb loaded from {:s}'.format(self.name, method,
+                                                            cache_file))
             return roidb
 
         if self._image_set in self._gt_splits:
@@ -176,7 +182,7 @@ class coco(imdb):
             roidb = self._load_proposals(method, None)
         with open(cache_file, 'wb') as fid:
             cPickle.dump(roidb, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'wrote {:s} roidb to {:s}'.format(method, cache_file)
+        print('wrote {:s} roidb to {:s}'.format(method, cache_file))
         return roidb
 
     def _load_proposals(self, method, gt_roidb):
@@ -198,10 +204,10 @@ class coco(imdb):
             'edge_boxes_70']
         assert method in valid_methods
 
-        print 'Loading {} boxes'.format(method)
+        print('Loading {} boxes'.format(method))
         for i, index in enumerate(self._image_index):
             if i % 1000 == 0:
-                print '{:d} / {:d}'.format(i + 1, len(self._image_index))
+                print('{:d} / {:d}'.format(i + 1, len(self._image_index)))
 
             box_file = osp.join(
                 cfg.DATA_DIR, 'coco_proposals', method, 'mat',
@@ -235,7 +241,7 @@ class coco(imdb):
         if osp.exists(cache_file):
             with open(cache_file, 'rb') as fid:
                 roidb = cPickle.load(fid)
-            print '{} gt roidb loaded from {}'.format(self.name, cache_file)
+            print('{} gt roidb loaded from {}'.format(self.name, cache_file))
             return roidb
 
         gt_roidb = [self._load_coco_annotation(index)
@@ -243,7 +249,7 @@ class coco(imdb):
 
         with open(cache_file, 'wb') as fid:
             cPickle.dump(gt_roidb, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'wrote gt roidb to {}'.format(cache_file)
+        print('wrote gt roidb to {}'.format(cache_file))
         return gt_roidb
 
     def _load_coco_annotation(self, index):
@@ -327,18 +333,18 @@ class coco(imdb):
         precision = \
             coco_eval.eval['precision'][ind_lo:(ind_hi + 1), :, :, 0, 2]
         ap_default = np.mean(precision[precision > -1])
-        print ('~~~~ Mean and per-category AP @ IoU=[{:.2f},{:.2f}] '
-               '~~~~').format(IoU_lo_thresh, IoU_hi_thresh)
-        print '{:.1f}'.format(100 * ap_default)
+        print(('~~~~ Mean and per-category AP @ IoU=[{:.2f},{:.2f}] '
+               '~~~~').format(IoU_lo_thresh, IoU_hi_thresh))
+        print('{:.1f}'.format(100 * ap_default))
         for cls_ind, cls in enumerate(self.classes):
             if cls == '__background__':
                 continue
             # minus 1 because of __background__
             precision = coco_eval.eval['precision'][ind_lo:(ind_hi + 1), :, cls_ind - 1, 0, 2]
             ap = np.mean(precision[precision > -1])
-            print '{:.1f}'.format(100 * ap)
+            print('{:.1f}'.format(100 * ap))
 
-        print '~~~~ Summary metrics ~~~~'
+        print('~~~~ Summary metrics ~~~~')
         coco_eval.summarize()
         cfg.mAP = coco_eval.stats
 
@@ -353,12 +359,12 @@ class coco(imdb):
         eval_file = osp.join(output_dir, 'detection_results.pkl')
         with open(eval_file, 'wb') as fid:
             cPickle.dump(coco_eval, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'Wrote COCO eval results to: {}'.format(eval_file)
+        print('Wrote COCO eval results to: {}'.format(eval_file))
 
     def _coco_results_one_category(self, boxes, cat_id):
         results = []
         for im_ind, index in enumerate(self.image_index):
-            if type(boxes[im_ind]) == list:
+            if isinstance(boxes[im_ind], list):
                 continue
             dets = boxes[im_ind].astype(np.float)
             if dets == []:
@@ -397,12 +403,12 @@ class coco(imdb):
         for cls_ind, cls in enumerate(self.classes):
             if cls == '__background__':
                 continue
-            print 'Collecting {} results ({:d}/{:d})'.format(cls, cls_ind,
-                                                          self.num_classes - 1)
+            print('Collecting {} results ({:d}/{:d})'.format(cls, cls_ind,
+                                                          self.num_classes - 1))
             coco_cat_id = self._class_to_coco_cat_id[cls]
             results.extend(self._coco_results_one_category(all_boxes[cls_ind],
                                                            coco_cat_id))
-        print 'Writing results json to {}'.format(res_file)
+        print('Writing results json to {}'.format(res_file))
         with open(res_file, 'w') as fid:
             json.dump(results, fid)
 

--- a/yolo/utils/test/datasets/factory.py
+++ b/yolo/utils/test/datasets/factory.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------
 
 """Factory method for easily getting imdbs by name."""
+from __future__ import print_function
 
 __sets = {}
 
@@ -37,8 +38,8 @@ __sets['person_head'] = (lambda: person_head())
 
 def get_imdb(name):
     """Get an imdb (image database) by name."""
-    if not __sets.has_key(name):
-        print __sets
+    if name not in __sets:
+        print(__sets)
         raise KeyError('Unknown dataset: {}'.format(name))
     return __sets[name]()
 

--- a/yolo/utils/test/datasets/imdb.py
+++ b/yolo/utils/test/datasets/imdb.py
@@ -13,6 +13,11 @@ import numpy as np
 import scipy.sparse
 from fast_rcnn.config import cfg
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 class imdb(object):
     """Image database."""
 
@@ -140,7 +145,7 @@ class imdb(object):
                         [256**2, 512**2],  # 256-512
                         [512**2, 1e5**2],  # 512-inf
                       ]
-        assert areas.has_key(area), 'unknown area range: {}'.format(area)
+        assert area in areas, 'unknown area range: {}'.format(area)
         area_range = area_ranges[areas[area]]
         gt_overlaps = np.zeros(0)
         num_pos = 0

--- a/yolo/utils/test/datasets/pascal_voc.py
+++ b/yolo/utils/test/datasets/pascal_voc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast R-CNN
 # Copyright (c) 2015 Microsoft
@@ -18,6 +19,11 @@ import subprocess
 import uuid
 from voc_eval import voc_eval
 from fast_rcnn.config import cfg
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 class pascal_voc(imdb):
     def __init__(self, image_set, year, devkit_path=None):
@@ -99,14 +105,14 @@ class pascal_voc(imdb):
         if os.path.exists(cache_file):
             with open(cache_file, 'rb') as fid:
                 roidb = cPickle.load(fid)
-            print '{} gt roidb loaded from {}'.format(self.name, cache_file)
+            print('{} gt roidb loaded from {}'.format(self.name, cache_file))
             return roidb
 
         gt_roidb = [self._load_pascal_annotation(index)
                     for index in self.image_index]
         with open(cache_file, 'wb') as fid:
             cPickle.dump(gt_roidb, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'wrote gt roidb to {}'.format(cache_file)
+        print('wrote gt roidb to {}'.format(cache_file))
 
         return gt_roidb
 
@@ -123,7 +129,7 @@ class pascal_voc(imdb):
         if os.path.exists(cache_file):
             with open(cache_file, 'rb') as fid:
                 roidb = cPickle.load(fid)
-            print '{} ss roidb loaded from {}'.format(self.name, cache_file)
+            print('{} ss roidb loaded from {}'.format(self.name, cache_file))
             return roidb
 
         if int(self._year) == 2007 or self._image_set != 'test':
@@ -134,7 +140,7 @@ class pascal_voc(imdb):
             roidb = self._load_selective_search_roidb(None)
         with open(cache_file, 'wb') as fid:
             cPickle.dump(roidb, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'wrote ss roidb to {}'.format(cache_file)
+        print('wrote ss roidb to {}'.format(cache_file))
 
         return roidb
 
@@ -150,7 +156,7 @@ class pascal_voc(imdb):
 
     def _load_rpn_roidb(self, gt_roidb):
         filename = self.config['rpn_file']
-        print 'loading {}'.format(filename)
+        print('loading {}'.format(filename))
         assert os.path.exists(filename), \
                'rpn data not found at: {}'.format(filename)
         with open(filename, 'rb') as f:
@@ -251,7 +257,7 @@ class pascal_voc(imdb):
         for cls_ind, cls in enumerate(self.classes):
             if cls == '__background__':
                 continue
-            print 'Writing {} VOC results file'.format(cls)
+            print('Writing {} VOC results file'.format(cls))
             filename = self._get_voc_results_file_template().format(cls)
             if not os.path.exists(os.path.dirname(filename)):
                 os.makedirs(os.path.dirname(filename))
@@ -283,7 +289,7 @@ class pascal_voc(imdb):
         aps = []
         # The PASCAL VOC metric changed in 2010
         use_07_metric = True if int(self._year) < 2010 else False
-        print 'VOC07 metric? ' + ('Yes' if use_07_metric else 'No')
+        print('VOC07 metric? ' + ('Yes' if use_07_metric else 'No'))
         if not os.path.isdir(output_dir):
             os.mkdir(output_dir)
         for i, cls in enumerate(self._classes):
@@ -307,9 +313,9 @@ class pascal_voc(imdb):
         cfg.mAP = np.mean(aps)
 
     def _do_matlab_eval(self, output_dir='output'):
-        print '-----------------------------------------------------'
-        print 'Computing results with the official MATLAB eval code.'
-        print '-----------------------------------------------------'
+        print('-----------------------------------------------------')
+        print('Computing results with the official MATLAB eval code.')
+        print('-----------------------------------------------------')
         path = os.path.join(cfg.ROOT_DIR, 'lib', 'datasets',
                             'VOCdevkit-matlab-wrapper')
         cmd = 'cd {} && '.format(path)

--- a/yolo/utils/test/datasets/person_eval.py
+++ b/yolo/utils/test/datasets/person_eval.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast/er R-CNN
 # Licensed under The MIT License [see LICENSE for details]
@@ -106,10 +107,10 @@ def person_eval(detpath,
         for i, imagename in enumerate(imagenames):
             recs[imagename] = parse_rec(annopath.format(imagename))
             if i % 100 == 0:
-                print 'Reading annotation for {:d}/{:d}'.format(
-                    i + 1, len(imagenames))
+                print('Reading annotation for {:d}/{:d}'.format(
+                    i + 1, len(imagenames)))
         # save
-        print 'Saving cached annotations to {:s}'.format(cachefile)
+        print('Saving cached annotations to {:s}'.format(cachefile))
         with open(cachefile, 'w') as f:
             cPickle.dump(recs, f)
     else:

--- a/yolo/utils/test/datasets/person_head.py
+++ b/yolo/utils/test/datasets/person_head.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast R-CNN
 # Copyright (c) 2015 Microsoft
@@ -18,6 +19,11 @@ import subprocess
 import uuid
 from person_eval import person_eval
 from fast_rcnn.config import cfg
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 class person_head(imdb):
     def __init__(self, devkit_path=None):
@@ -99,7 +105,7 @@ class person_head(imdb):
         for cls_ind, cls in enumerate(self.classes):
             if cls == '__background__':
                 continue
-            print 'Writing {} VOC results file'.format(cls)
+            print('Writing {} VOC results file'.format(cls))
             filename = self._get_voc_results_file_template().format(cls)
             if not os.path.exists(os.path.dirname(filename)):
                 os.makedirs(os.path.dirname(filename))
@@ -131,7 +137,7 @@ class person_head(imdb):
         aps = []
         # The PASCAL VOC metric changed in 2010
         use_07_metric = True #True if int(self._year) < 2010 else False
-        print 'VOC07 metric? ' + ('Yes' if use_07_metric else 'No')
+        print('VOC07 metric? ' + ('Yes' if use_07_metric else 'No'))
         if not os.path.isdir(output_dir):
             os.mkdir(output_dir)
         for i, cls in enumerate(self._classes):

--- a/yolo/utils/test/datasets/voc_eval.py
+++ b/yolo/utils/test/datasets/voc_eval.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast/er R-CNN
 # Licensed under The MIT License [see LICENSE for details]
@@ -108,10 +109,10 @@ def voc_eval(detpath,
         for i, imagename in enumerate(imagenames):
             recs[imagename] = parse_rec(annopath.format(imagename))
             if i % 100 == 0:
-                print 'Reading annotation for {:d}/{:d}'.format(
-                    i + 1, len(imagenames))
+                print('Reading annotation for {:d}/{:d}'.format(
+                    i + 1, len(imagenames)))
         # save
-        print 'Saving cached annotations to {:s}'.format(cachefile)
+        print('Saving cached annotations to {:s}'.format(cachefile))
         with open(cachefile, 'w') as f:
             cPickle.dump(recs, f)
     else:

--- a/yolo/utils/test/fast_rcnn/config.py
+++ b/yolo/utils/test/fast_rcnn/config.py
@@ -247,17 +247,17 @@ def _merge_a_into_b(a, b):
     """Merge config dictionary a into config dictionary b, clobbering the
     options in b whenever they are also specified in a.
     """
-    if type(a) is not edict:
+    if not isinstance(a, edict):
         return
 
     for k, v in a.iteritems():
         # a must specify keys that are in b
-        if not b.has_key(k):
+        if k not in b:
             raise KeyError('{} is not a valid config key'.format(k))
 
         # the types must match, too
         old_type = type(b[k])
-        if old_type is not type(v):
+        if not isinstance(v, old_type):
             if isinstance(b[k], np.ndarray):
                 v = np.array(v, dtype=b[k].dtype)
             else:
@@ -266,7 +266,7 @@ def _merge_a_into_b(a, b):
                                                             type(v), k))
 
         # recursively merge dicts
-        if type(v) is edict:
+        if isinstance(v, edict):
             try:
                 _merge_a_into_b(a[k], b[k])
             except:
@@ -291,16 +291,16 @@ def cfg_from_list(cfg_list):
         key_list = k.split('.')
         d = __C
         for subkey in key_list[:-1]:
-            assert d.has_key(subkey)
+            assert subkey in d
             d = d[subkey]
         subkey = key_list[-1]
-        assert d.has_key(subkey)
+        assert subkey in d
         try:
             value = literal_eval(v)
         except:
             # handle the case when v is a string literal
             value = v
-        assert type(value) == type(d[subkey]), \
+        assert isinstance(value, type(d[subkey])), \
             'type {} does not match original type {}'.format(
             type(value), type(d[subkey]))
         d[subkey] = value

--- a/yolo/utils/test/fast_rcnn/test.py
+++ b/yolo/utils/test/fast_rcnn/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from fast_rcnn.config import cfg, get_output_dir
 import numpy as np
 import cv2
@@ -6,6 +7,11 @@ from fast_rcnn.nms_wrapper import nms, soft_nms
 import cPickle
 import os
 import time
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 def im_detect(net, im, targe_size):
     im_orig = im.astype(np.float32, copy=True)
@@ -237,18 +243,18 @@ def single_scale_test_net(net, imdb, targe_size=(320, 320), vis=False):
                 if vis:
                     vis_detections(im, imdb.classes[j], cls_dets)
 
-        print 'im_detect: {:d}/{:d} {:.4f}s'.format(i + 1, num_images, net_time / (i + 1))
+        print('im_detect: {:d}/{:d} {:.4f}s'.format(i + 1, num_images, net_time / (i + 1)))
 
     det_file = os.path.join(output_dir, 'detections.pkl')
     with open(det_file, 'wb') as f:
         cPickle.dump(all_boxes, f, cPickle.HIGHEST_PROTOCOL)
 
     if imdb.name == 'voc_2012_test':
-        print 'Saving detections'
+        print('Saving detections')
         imdb.config['use_salt'] = False
         imdb._write_voc_results_file(all_boxes)
     else:
-        print 'Evaluating detections'
+        print('Evaluating detections')
         imdb.evaluate_detections(all_boxes, output_dir)
 
 
@@ -331,18 +337,18 @@ def multi_scale_test_net_320(net, imdb, vis=False):
                 if vis:
                     vis_detections(im, imdb.classes[j], cls_dets)
 
-        print 'im_detect: {:d}/{:d}'.format(i + 1, num_images)
+        print('im_detect: {:d}/{:d}'.format(i + 1, num_images))
 
     det_file = os.path.join(output_dir, 'detections.pkl')
     with open(det_file, 'wb') as f:
         cPickle.dump(all_boxes, f, cPickle.HIGHEST_PROTOCOL)
 
     if imdb.name == 'voc_2012_test':
-        print 'Saving detections'
+        print('Saving detections')
         imdb.config['use_salt'] = False
         imdb._write_voc_results_file(all_boxes)
     else:
-        print 'Evaluating detections'
+        print('Evaluating detections')
         imdb.evaluate_detections(all_boxes, output_dir)
 
 
@@ -421,16 +427,16 @@ def multi_scale_test_net_512(net, imdb, vis=False):
                 if vis:
                     vis_detections(im, imdb.classes[j], cls_dets)
 
-        print 'im_detect: {:d}/{:d}'.format(i + 1, num_images)
+        print('im_detect: {:d}/{:d}'.format(i + 1, num_images))
 
     det_file = os.path.join(output_dir, 'detections.pkl')
     with open(det_file, 'wb') as f:
         cPickle.dump(all_boxes, f, cPickle.HIGHEST_PROTOCOL)
 
     if imdb.name == 'voc_2012_test':
-        print 'Saving detections'
+        print('Saving detections')
         imdb.config['use_salt'] = False
         imdb._write_voc_results_file(all_boxes)
     else:
-        print 'Evaluating detections'
+        print('Evaluating detections')
         imdb.evaluate_detections(all_boxes, output_dir)

--- a/yolo/utils/test/pycocotools/coco.py
+++ b/yolo/utils/test/pycocotools/coco.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'tylin'
 __version__ = '1.0.1'
 # Interface for accessing the Microsoft COCO dataset.
@@ -74,16 +75,16 @@ class COCO:
         self.imgs = {}
         self.cats = {}
         if not annotation_file == None:
-            print 'loading annotations into memory...'
+            print('loading annotations into memory...')
             tic = time.time()
             dataset = json.load(open(annotation_file, 'r'))
-            print 'Done (t=%0.2fs)'%(time.time()- tic)
+            print('Done (t=%0.2fs)'%(time.time()- tic))
             self.dataset = dataset
             self.createIndex()
 
     def createIndex(self):
         # create index
-        print 'creating index...'
+        print('creating index...')
         anns = {}
         imgToAnns = {}
         catToImgs = {}
@@ -110,7 +111,7 @@ class COCO:
                 for ann in self.dataset['annotations']:
                     catToImgs[ann['category_id']] += [ann['image_id']]
 
-        print 'index created!'
+        print('index created!')
 
         # create class members
         self.anns = anns
@@ -125,7 +126,7 @@ class COCO:
         :return:
         """
         for key, value in self.dataset['info'].items():
-            print '%s: %s'%(key, value)
+            print('%s: %s'%(key, value))
 
     def getAnnIds(self, imgIds=[], catIds=[], areaRng=[], iscrowd=None):
         """
@@ -136,8 +137,8 @@ class COCO:
                iscrowd (boolean)       : get anns for given crowd label (False or True)
         :return: ids (int array)       : integer array of ann ids
         """
-        imgIds = imgIds if type(imgIds) == list else [imgIds]
-        catIds = catIds if type(catIds) == list else [catIds]
+        imgIds = imgIds if isinstance(imgIds, list) else [imgIds]
+        catIds = catIds if isinstance(catIds, list) else [catIds]
 
         if len(imgIds) == len(catIds) == len(areaRng) == 0:
             anns = self.dataset['annotations']
@@ -164,9 +165,9 @@ class COCO:
         :param catIds (int array)  : get cats for given cat ids
         :return: ids (int array)   : integer array of cat ids
         """
-        catNms = catNms if type(catNms) == list else [catNms]
-        supNms = supNms if type(supNms) == list else [supNms]
-        catIds = catIds if type(catIds) == list else [catIds]
+        catNms = catNms if isinstance(catNms, list) else [catNms]
+        supNms = supNms if isinstance(supNms, list) else [supNms]
+        catIds = catIds if isinstance(catIds, list) else [catIds]
 
         if len(catNms) == len(supNms) == len(catIds) == 0:
             cats = self.dataset['categories']
@@ -185,8 +186,8 @@ class COCO:
         :param catIds (int array) : get imgs with all given cats
         :return: ids (int array)  : integer array of img ids
         '''
-        imgIds = imgIds if type(imgIds) == list else [imgIds]
-        catIds = catIds if type(catIds) == list else [catIds]
+        imgIds = imgIds if isinstance(imgIds, list) else [imgIds]
+        catIds = catIds if isinstance(catIds, list) else [catIds]
 
         if len(imgIds) == len(catIds) == 0:
             ids = self.imgs.keys()
@@ -205,9 +206,9 @@ class COCO:
         :param ids (int array)       : integer ids specifying anns
         :return: anns (object array) : loaded ann objects
         """
-        if type(ids) == list:
+        if isinstance(ids, list):
             return [self.anns[id] for id in ids]
-        elif type(ids) == int:
+        elif isinstance(ids, int):
             return [self.anns[ids]]
 
     def loadCats(self, ids=[]):
@@ -216,9 +217,9 @@ class COCO:
         :param ids (int array)       : integer ids specifying cats
         :return: cats (object array) : loaded cat objects
         """
-        if type(ids) == list:
+        if isinstance(ids, list):
             return [self.cats[id] for id in ids]
-        elif type(ids) == int:
+        elif isinstance(ids, int):
             return [self.cats[ids]]
 
     def loadImgs(self, ids=[]):
@@ -227,9 +228,9 @@ class COCO:
         :param ids (int array)       : integer ids specifying img
         :return: imgs (object array) : loaded img objects
         """
-        if type(ids) == list:
+        if isinstance(ids, list):
             return [self.imgs[id] for id in ids]
-        elif type(ids) == int:
+        elif isinstance(ids, int):
             return [self.imgs[ids]]
 
     def showAnns(self, anns):
@@ -250,7 +251,7 @@ class COCO:
             color = []
             for ann in anns:
                 c = np.random.random((1, 3)).tolist()[0]
-                if type(ann['segmentation']) == list:
+                if isinstance(ann['segmentation'], list):
                     # polygon
                     for seg in ann['segmentation']:
                         poly = np.array(seg).reshape((len(seg)/2, 2))
@@ -259,7 +260,7 @@ class COCO:
                 else:
                     # mask
                     t = self.imgs[ann['image_id']]
-                    if type(ann['segmentation']['counts']) == list:
+                    if isinstance(ann['segmentation']['counts'], list):
                         rle = mask.frPyObjects([ann['segmentation']], t['height'], t['width'])
                     else:
                         rle = [ann['segmentation']]
@@ -276,7 +277,7 @@ class COCO:
             ax.add_collection(p)
         elif datasetType == 'captions':
             for ann in anns:
-                print ann['caption']
+                print(ann['caption'])
 
     def loadRes(self, resFile):
         """
@@ -289,10 +290,10 @@ class COCO:
         # res.dataset['info'] = copy.deepcopy(self.dataset['info'])
         # res.dataset['licenses'] = copy.deepcopy(self.dataset['licenses'])
 
-        print 'Loading and preparing results...     '
+        print('Loading and preparing results...     ')
         tic = time.time()
         anns    = json.load(open(resFile))
-        assert type(anns) == list, 'results in not an array of objects'
+        assert isinstance(anns, list), 'results in not an array of objects'
         annsImgIds = [ann['image_id'] for ann in anns]
         assert set(annsImgIds) == (set(annsImgIds) & set(self.getImgIds())), \
                'Results do not correspond to current coco set'
@@ -320,7 +321,7 @@ class COCO:
                     ann['bbox'] = mask.toBbox([ann['segmentation']])[0]
                 ann['id'] = id+1
                 ann['iscrowd'] = 0
-        print 'DONE (t=%0.2fs)'%(time.time()- tic)
+        print('DONE (t=%0.2fs)'%(time.time()- tic))
 
         res.dataset['annotations'] = anns
         res.createIndex()
@@ -334,7 +335,7 @@ class COCO:
         :return:
         '''
         if tarDir is None:
-            print 'Please specify target directory'
+            print('Please specify target directory')
             return -1
         if len(imgIds) == 0:
             imgs = self.imgs.values()
@@ -348,4 +349,4 @@ class COCO:
             fname = os.path.join(tarDir, img['file_name'])
             if not os.path.exists(fname):
                 urllib.urlretrieve(img['coco_url'], fname)
-            print 'downloaded %d/%d images (t=%.1fs)'%(i, N, time.time()- tic)
+            print('downloaded %d/%d images (t=%.1fs)'%(i, N, time.time()- tic))

--- a/yolo/utils/test/pycocotools/cocoeval.py
+++ b/yolo/utils/test/pycocotools/cocoeval.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'tsungyi'
 
 import numpy as np
@@ -6,6 +7,12 @@ import time
 from collections import defaultdict
 import mask
 import copy
+
+try:
+    basestring     # Python 2
+except NameError:  # Python 3
+    basestring = (str, )
+
 
 class COCOeval:
     # Interface for evaluating detection on the Microsoft COCO dataset.
@@ -89,9 +96,9 @@ class COCOeval:
             # modify segmentation by reference
             for obj in objs:
                 t = coco.imgs[obj['image_id']]
-                if type(obj['segmentation']) == list:
-                    if type(obj['segmentation'][0]) == dict:
-                        print 'debug'
+                if isinstance(obj['segmentation'], list):
+                    if isinstance(obj['segmentation'][0], dict):
+                        print('debug')
                     obj['segmentation'] = mask.frPyObjects(obj['segmentation'],t['height'],t['width'])
                     if len(obj['segmentation']) == 1:
                         obj['segmentation'] = obj['segmentation'][0]
@@ -99,10 +106,10 @@ class COCOeval:
                         # an object can have multiple polygon regions
                         # merge them into one RLE mask
                         obj['segmentation'] = mask.merge(obj['segmentation'])
-                elif type(obj['segmentation']) == dict and type(obj['segmentation']['counts']) == list:
+                elif isinstance(obj['segmentation'], dict) and isinstance(obj['segmentation']['counts'], list):
                     obj['segmentation'] = mask.frPyObjects([obj['segmentation']],t['height'],t['width'])[0]
-                elif type(obj['segmentation']) == dict and \
-                     type(obj['segmentation']['counts'] == unicode or type(obj['segmentation']['counts']) == str):
+                elif (isinstance(obj['segmentation'], dict) and
+                      isinstance(obj['segmentation']['counts'], basestring)):
                     pass
                 else:
                     raise Exception('segmentation format not supported.')
@@ -132,7 +139,7 @@ class COCOeval:
         :return: None
         '''
         tic = time.time()
-        print 'Running per image evaluation...      '
+        print('Running per image evaluation...      ')
         p = self.params
         p.imgIds = list(np.unique(p.imgIds))
         if p.useCats:
@@ -158,7 +165,7 @@ class COCOeval:
              ]
         self._paramsEval = copy.deepcopy(self.params)
         toc = time.time()
-        print 'DONE (t=%0.2fs).'%(toc-tic)
+        print('DONE (t=%0.2fs).'%(toc-tic))
 
     def computeIoU(self, imgId, catId):
         p = self.params
@@ -212,7 +219,7 @@ class COCOeval:
 
         # sort dt highest score first, sort gt ignore last
         # gt = sorted(gt, key=lambda x: x['_ignore'])
-        gtind = [ind for (ind, g) in sorted(enumerate(gt), key=lambda (ind, g): g['_ignore']) ]
+        gtind = [ind for (ind, g) in sorted(enumerate(gt), key=lambda ind_g: ind_g[1]['_ignore']) ]
 
         gt = [gt[ind] for ind in gtind]
         dt = sorted(dt, key=lambda x: -x['score'])[0:maxDet]
@@ -277,10 +284,10 @@ class COCOeval:
         :param p: input params for evaluation
         :return: None
         '''
-        print 'Accumulating evaluation results...   '
+        print('Accumulating evaluation results...   ')
         tic = time.time()
         if not self.evalImgs:
-            print 'Please run evaluate() first'
+            print('Please run evaluate() first')
         # allows input customized parameters
         if p is None:
             p = self.params
@@ -371,7 +378,7 @@ class COCOeval:
             'recall':   recall,
         }
         toc = time.time()
-        print 'DONE (t=%0.2fs).'%( toc-tic )
+        print('DONE (t=%0.2fs).'%( toc-tic ))
 
     def summarize(self):
         '''
@@ -406,7 +413,7 @@ class COCOeval:
                 mean_s = -1
             else:
                 mean_s = np.mean(s[s>-1])
-            print iStr.format(titleStr, typeStr, iouStr, areaStr, maxDetsStr, '%.3f'%(float(mean_s)))
+            print(iStr.format(titleStr, typeStr, iouStr, areaStr, maxDetsStr, '%.3f'%(float(mean_s))))
             return mean_s
 
         if not self.eval:

--- a/yolo/vedanet/models/_darknet.py
+++ b/yolo/vedanet/models/_darknet.py
@@ -115,11 +115,11 @@ class WeightLoader:
 
     def load_layer(self, layer):
         """ Load weights for a layer from the weights file """
-        if type(layer) == nn.Conv2d:
+        if isinstance(layer, nn.Conv2d):
             self._load_conv(layer)
-        elif type(layer) == vn_layer.Conv2dBatchLeaky:
+        elif isinstance(layer, vn_layer.Conv2dBatchLeaky):
             self._load_convbatch(layer)
-        elif type(layer) == nn.Linear:
+        elif isinstance(layer, nn.Linear):
             self._load_fc(layer)
         else:
             raise NotImplementedError(f'The layer you are trying to load is not supported [{type(layer)}]')
@@ -193,11 +193,11 @@ class WeightSaver:
 
     def save_layer(self, layer):
         """ save weights for a layer """
-        if type(layer) == nn.Conv2d:
+        if isinstance(layer, nn.Conv2d):
             self._save_conv(layer)
-        elif type(layer) == vn_layer.Conv2dBatchLeaky:
+        elif isinstance(layer, vn_layer.Conv2dBatchLeaky):
             self._save_convbatch(layer)
-        elif type(layer) == nn.Linear:
+        elif isinstance(layer, nn.Linear):
             self._save_fc(layer)
         else:
             raise NotImplementedError(f'The layer you are trying to save is not supported [{type(layer)}]')


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Also __basestring__, __unicode__, and __xrange__ were removed in Python 3 so this PR makes changes to have equivalent functionality in both Python 2 and Python 3.

https://twitter.com/raymondh/status/1080961135493316608 and http://pythonclock.org