### PR TITLE
a tensor type error in GetBoundingBoxes.apply

### DIFF
--- a/yolo/vedanet/data/transform/_postprocess.py
+++ b/yolo/vedanet/data/transform/_postprocess.py
@@ -99,9 +99,8 @@ class GetBoundingBoxes(BaseTransform):
                 num_classes,coords.size(3)).contiguous().view(coords.size(0),coords.size(1),-1,coords.size(3))
         coords = coords[score_thresh[..., None].expand_as(coords)].view(-1, 4)
         scores = cls_scores[score_thresh].view(-1, 1)
-        idx = (torch.arange(num_classes)).repeat(batch, num_anchors, w*h).cuda()
+        idx = (torch.arange(num_classes)).repeat(batch, num_anchors, w*h).cuda().float()
         idx = idx[score_thresh].view(-1, 1)
-        idx = idx.float()
         detections = torch.cat([coords, scores, idx], dim=1)
 
         # Get indexes of splits between images of batch


### PR DESCRIPTION
When I run python example/test.py Yolov3, I got

Traceback (most recent call last):
File "examples/test.py", line 33, in
vn.engine.VOCTest(hyper_params)
File "./vedanet/engine/_voc_test.py", line 89, in VOCTest
output, loss = net(data, box)
File "/home/ww/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 489, in call
result = self.forward(*input, **kwargs)
File "./vedanet/models/_lightnet.py", line 100, in forward
tdets.append(self.postprocessidx)
File "./vedanet/data/transform/util.py", line 44, in call
data = tf(data)
File "./vedanet/data/transform/util.py", line 65, in call
return self.apply(data, **self.dict)
File "./vedanet/data/transform/_postprocess.py", line 108, in apply
detections = torch.cat([coords, scores, idx], dim=1)
RuntimeError: Expected object of scalar type Float but got scalar type Long for sequence elment 2 in sequence argument at position #1 'tensors'

So I convert idx to floattype and it works.