### PR TITLE
"referenced before assignment" error in _postprocess.apply

### DIFF
--- a/yolo/vedanet/data/transform/_postprocess.py
+++ b/yolo/vedanet/data/transform/_postprocess.py
@@ -81,8 +81,9 @@ class GetBoundingBoxes(BaseTransform):
                     cls_scores = (cls_scores * conf_scores.unsqueeze(2).expand_as(cls_scores)).transpose(2,3)
                     cls_scores = cls_scores.contiguous().view(cls_scores.size(0), cls_scores.size(1), -1)
         else:
-            cls_max = network_output[:, :, 4, :]
-            cls_max_idx = torch.zeros_like(cls_max)
+            cls_scores = network_output[:, :, 4, :]
+            #cls_max = network_output[:, :, 4, :]
+            #cls_max_idx = torch.zeros_like(cls_max)
 
         score_thresh = cls_scores > conf_thresh
         score_thresh_flat = score_thresh.view(-1)
@@ -100,7 +101,7 @@ class GetBoundingBoxes(BaseTransform):
         coords = coords[score_thresh[..., None].expand_as(coords)].view(-1, 4)
         scores = cls_scores[score_thresh].view(-1, 1)
         idx = (torch.arange(num_classes)).repeat(batch, num_anchors, w*h).cuda()
-        idx = idx[score_thresh].view(-1, 1)
+        idx = idx[score_thresh].view(-1, 1).float()
         detections = torch.cat([coords, scores, idx], dim=1)
 
         # Get indexes of splits between images of batch


### PR DESCRIPTION
Thanks for sharing! When I run python example/test.py Yolov3, I got

Traceback (most recent call last):
  File "./ObjectDetection-OneStageDet/yolo/examples/test.py", line 33, in <module>
    vn.engine.VOCTest(hyper_params)
  File "./vedanet/engine/_voc_test.py", line 89, in VOCTest
    output, loss = net(data, box)
  File "/home/m203/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 489, in __call__
    result = self.forward(*input, **kwargs)
  File "./vedanet/models/_lightnet.py", line 100, in forward
    tdets.append(self.postprocess[idx](outputs[idx]))
  File "./vedanet/data/transform/util.py", line 44, in __call__
    data = tf(data)
  File "./vedanet/data/transform/util.py", line 65, in __call__
    return self.apply(data, **self.__dict__)
  File "./vedanet/data/transform/_postprocess.py", line 88, in apply
    score_thresh = cls_scores > conf_thresh
UnboundLocalError: local variable 'cls_scores' referenced before assignment

What needs special explanation is I have only one class in my experiment. So I fixed some code in ObjectDetection-OneStageDet/yolo/vedanet/data/transform/_postprocess.py and it works.