### PR TITLE
Solve the type error

### DIFF
--- a/yolo/cfgs/yolov2.yml
+++ b/yolo/cfgs/yolov2.yml
@@ -5,12 +5,12 @@ log_name: "logs"
 
 labels: ["aeroplane", "bicycle", "bird", "boat", "bottle", "bus", "car", "cat", "chair", "cow", "diningtable", "dog", "horse", "motorbike", "person", "pottedplant", "sheep", "sofa", "train", "tvmonitor"]
 
-data_root_dir: "/data2/yichaoxiong/data/VOCdevkit/onedet_cache"
+data_root_dir: "VOCdevkit/onedet_cache"
 
 train:
     dataset: "train"
-    stdout: False
-    gpus: "2"
+    stdout: True
+    gpus: "0"
     nworkers: 16
     pin_mem: True
 
@@ -36,9 +36,9 @@ train:
 
 test:
     dataset: "test"
-    stdout: True
-    gpus: "3"
-    nworkers: 8
+    stdout: False
+    gpus: "0"
+    nworkers: 4
     pin_mem: True
 
     input_shape: [544, 544]

--- a/yolo/examples/labels.py
+++ b/yolo/examples/labels.py
@@ -13,7 +13,7 @@ sys.path.insert(0, '.')
 import brambox.boxes as bbb
 
 DEBUG = True        # Enable some debug prints with extra information
-ROOT = '/data2/yichaoxiong/data/VOCdevkit'       # Root folder where the VOCdevkit is located
+ROOT = "/mnt/m2/mzcc/ObjectDetection-OneStageDet/yolo/VOCdevkit" #'/data2/yichaoxiong/data/VOCdevkit'       # Root folder where the VOCdevkit is located
 
 TRAINSET = [
     ('2012', 'train'),

--- a/yolo/examples/labels.py
+++ b/yolo/examples/labels.py
@@ -13,7 +13,7 @@ sys.path.insert(0, '.')
 import brambox.boxes as bbb
 
 DEBUG = True        # Enable some debug prints with extra information
-ROOT = "/mnt/m2/mzcc/ObjectDetection-OneStageDet/yolo/VOCdevkit" #'/data2/yichaoxiong/data/VOCdevkit'       # Root folder where the VOCdevkit is located
+ROOT = "VOCdevkit" #'/data2/yichaoxiong/data/VOCdevkit'       # Root folder where the VOCdevkit is located
 
 TRAINSET = [
     ('2012', 'train'),

--- a/yolo/vedanet/data/transform/_postprocess.py
+++ b/yolo/vedanet/data/transform/_postprocess.py
@@ -101,7 +101,7 @@ class GetBoundingBoxes(BaseTransform):
         scores = cls_scores[score_thresh].view(-1, 1)
         idx = (torch.arange(num_classes)).repeat(batch, num_anchors, w*h).cuda()
         idx = idx[score_thresh].view(-1, 1)
-        detections = torch.cat([coords, scores, idx], dim=1)
+        detections = torch.cat([coords, scores, idx.float().cuda()], dim=1)
 
         # Get indexes of splits between images of batch
         max_det_per_batch = num_anchors * h * w * num_classes


### PR DESCRIPTION
The original version outputs the following error during testing. This pull request provides a fix.

```
Traceback (most recent call last):
  File "examples/test.py", line 33, in <module>
    vn.engine.VOCTest(hyper_params)
  File "./vedanet/engine/_voc_test.py", line 89, in VOCTest
    output, loss = net(data, box)
  File ".../lib/python3.6/site-packages/torch/nn/modules/module.py", line 477, in __call__
    result = self.forward(*input, **kwargs)
  File "./vedanet/models/_lightnet.py", line 100, in forward
    tdets.append(self.postprocess[idx](outputs[idx]))
  File "./vedanet/data/transform/util.py", line 44, in __call__
    data = tf(data)
  File "./vedanet/data/transform/util.py", line 65, in __call__
    return self.apply(data, **self.__dict__)
  File "./vedanet/data/transform/_postprocess.py", line 104, in apply
    detections = torch.cat([coords, scores, idx], dim=1)
RuntimeError: Expected a Tensor of type torch.cuda.FloatTensor but found a type torch.cuda.LongTensor for sequence element 2 in sequence argument at position #1 'tensors'
```

